### PR TITLE
workout data by muscle group appears for a specific user

### DIFF
--- a/src/api/workoutAPI.js
+++ b/src/api/workoutAPI.js
@@ -1,1 +1,29 @@
 // All API calls for Workout data will reside here
+
+const getUidWorkouts = (uid) =>
+  new Promise((resolve, reject) => {
+    fetch(`http://localhost:8000/workouts?uid=${uid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+const getMgWorkouts = (uid, mgid) =>
+  new Promise((resolve, reject) => {
+    fetch(`http://localhost:8000/workouts?uid=${uid}&muscle_group_id_id=${mgid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+export { getUidWorkouts, getMgWorkouts };

--- a/src/app/pages/muscleGroups/[id]/page.js
+++ b/src/app/pages/muscleGroups/[id]/page.js
@@ -1,12 +1,29 @@
+'use client';
+
 import PropTypes from 'prop-types';
+import { getMgWorkouts } from '@/api/workoutAPI';
+import { useAuth } from '@/utils/context/authContext';
+import { useEffect, useState } from 'react';
+import WorkoutLog from '@/components/cards/WorkoutLog';
 
 function WorkoutsByMG({ params }) {
+  const [workouts, setWorkouts] = useState([]);
+  const { user } = useAuth();
   const { id } = params;
+
+  useEffect(() => {
+    getMgWorkouts(user.uid, id).then(setWorkouts);
+  }, [user.uid, id]);
+
+  console.log('current state of workouts', workouts);
 
   return (
     <>
       <h3>This is the page where we see all Workouts by Muscle Group!</h3>
       <p>This is the id: {id}</p>
+      {workouts.map((wo) => (
+        <WorkoutLog key={wo.id} workoutObj={wo} />
+      ))}
     </>
   );
 }

--- a/src/components/cards/WorkoutLog.js
+++ b/src/components/cards/WorkoutLog.js
@@ -1,5 +1,56 @@
-function WorkoutLog() {
-  return <h3>This is a reusable card component that will be used to display workouts that a user performed!</h3>;
+import PropTypes from 'prop-types';
+
+function WorkoutLog({ workoutObj }) {
+  // This is a reusable card component that will be used to display workouts that a user performed!
+
+  return (
+    <div className="d-flex flex-row justify-content-center">
+        <div className="woborder">
+          <div>Timestamp</div>
+          <div>{workoutObj.time_stamp}</div>
+        </div>
+        <div className="woborder">
+          <div>Name of workout</div>
+          <div>{workoutObj.name}</div>
+        </div>
+        <div className="woborder">
+          <div>Number of sets</div>
+          <div>{workoutObj.num_of_sets}</div>
+        </div>
+        <div className="woborder">
+          <div>Total amount of reps</div>
+          <div>{workoutObj.total_reps}</div>
+        </div>
+        <div className="woborder">
+          <div>Max weight of a set</div>
+          <div>{workoutObj.max_weight}</div>
+        </div>
+        <div className="woborder">
+          <div>Associated muscle group</div>
+          <div>{workoutObj.muscle_group_id.muscle_group}</div>
+        </div>
+        <div className="woborder">
+          <div>Did you complete the workout?</div>
+          {workoutObj.is_complete ? <div>Yes</div> : <div>No</div>}
+        </div>
+      </div>
+  );
 }
 
 export default WorkoutLog;
+
+WorkoutLog.propTypes = {
+  workoutObj: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    num_of_sets: PropTypes.number,
+    total_reps: PropTypes.number,
+    max_weight: PropTypes.number,
+    time_stamp: PropTypes.string,
+    is_complete: PropTypes.bool,
+    muscle_group_id: PropTypes.shape({
+      id: PropTypes.number,
+      muscle_group: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,3 +8,8 @@ body {
   color: rgb(239, 222, 222);
   padding: 140px;
 }
+
+.woborder {
+  border: 2px black solid;
+  padding: 3px;
+}


### PR DESCRIPTION
## Description
We have set up the application to now display workout data from a specific user (through their uid that is given by Google Auth), which can further be explained in the following bullet points:
- Created 2 API calls:
   -  One labeled `getUidWorkouts` to fetch all Workouts by uid (which will be implemented in the future).
   -  One labeled `getMgWorkouts` to fetch all Workouts by uid and muscle_group_id.
- Updated the specific Muscle Group page to include the state of workouts and to update the state of workouts when the array is modified in any way. With the addition of the map array method, the page will now also display a list of workouts that are specific to the muscle group of the page (given that a user has workouts with that muscle group available). 
- Updated the `WorkouLog` card component to render all of the data fed into the parameter and structure it in a manner that mimics a data table.
- Established global CSS for any className instance of "_woborder_" to ensure bordering and padding styles are consistent on each applied div.

## Motivation and Context
The motivation behind this pull request revolves around the simplicity and speed of the application. To put it into context, we wanted to allow the user to quickly access their workouts by muscle group, so that they can see in an easy-to-read view what has been working for them when they go for their next workout. So this required access to our backend tables to load a specific user's workout data, to enhance the page and card component to display that data, and a minor addition to CSS to divide each instance of a workout and its categories.

## How has this been tested?
### Console logging workout data for each page 
- We checked the current state of workouts in `/pages/muscleGroups/id` to see if the data was successfully fetched with the API call and set into the workouts. Eventually, we noticed the data populated in the console successfully.

### Creating workout data in Postman and checking for updates 
- After creating several instances of workout data, we came back to the `/pages/muscleGroups/id` where the data was successfully generated onto the page in the appropriate manner (see in screenshot below).

## Screenshots (if appropriate):
### Workout Logs that are filtered for Specific Muscle Group Page
<img width="2880" height="1548" alt="Screenshot 2025-09-05 at 2 13 35 PM" src="https://github.com/user-attachments/assets/e0c1ec2f-2da7-40f3-b315-9ef1d0980dd4" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)